### PR TITLE
DM+Weeklies fix, Development

### DIFF
--- a/Assist/Views/Dashboard/ViewModels/DashboardViewModel.cs
+++ b/Assist/Views/Dashboard/ViewModels/DashboardViewModel.cs
@@ -263,12 +263,21 @@ namespace Assist.Views.Dashboard.ViewModels
                         // if not 
                         if (ourTeam.Won)
                         {
-                            control.MatchScore = $"{ourTeam.RoundsWon} - {notOurTeam.RoundsWon}";
+                            var mode = match.MatchInformation.QueueID; // get gamemode --Shiick
+                            control.MatchScore =
+                                mode.ToLower().Equals("deathmatch")  // check for mode --Shiick
+                                ? $"{currentP.Stats.Kills} - {currentP.Stats.Kills}" // mode is deathmatch, show score --Shiick
+                                : $"{ourTeam.RoundsWon} - {notOurTeam.RoundsWon}"; // regular game --Shiick
                             control.ResultText = Properties.Resources.Profile_WonText;
                             control.MatchWin = true;
                         }
-                        else{
-                            control.MatchScore = $"{notOurTeam.RoundsWon} - {ourTeam.RoundsWon}";
+                        else
+                        {
+                            var mode = match.MatchInformation.QueueID; // get gamemode --Shiick
+                            control.MatchScore = 
+                                mode.ToLower().Equals("deathmatch") // check for mode --Shiick
+                                ? $"{currentP.Stats.Kills} - {match.Players.Max(player => player.Stats.Kills)}" // mode is deathmatch, show score. second one is MVP --Shiick
+                                : $"{ourTeam.RoundsWon} - {notOurTeam.RoundsWon}"; // regular game --Shiick
                             control.ResultText = Properties.Resources.Profile_LossText;
                             control.MatchWin = false;
                         }


### PR DESCRIPTION
- Temporary fixed dailies showing up in the weeklies area. Dirty fix. (Proper fix notes: adding a start time for missions in the ValNet API would fix all those issues if you check `ExpirationTime.Day-StartTime.Day`, if 1 -> this is a daily, if not, this is a weekly)
- Added score for deathmatch. Showing player kill count and winner kill count.
![image](https://user-images.githubusercontent.com/29106689/206997786-2fde0970-3b5f-41ba-92bf-b56d1262fa7e.png)
