### PR TITLE
Transparent title bar

### DIFF
--- a/Assist/Controls/Global/Popup/BasicPopup.axaml
+++ b/Assist/Controls/Global/Popup/BasicPopup.axaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              Width="1125"
-             Height="690"
+             Height="720"
              x:Class="Assist.Controls.Global.Popup.BasicPopup">
 	<Grid Background="#3D000000">
         <Border VerticalAlignment="Center"

--- a/Assist/Controls/Global/Popup/PopupMaster.axaml
+++ b/Assist/Controls/Global/Popup/PopupMaster.axaml
@@ -3,7 +3,7 @@
         xmlns:controls="using:Assist.Controls.Global.Popup">
   <Design.PreviewWith>
     <controls:PopupMaster Width="1125"
-                          Height="690"/>
+                          Height="720"/>
   </Design.PreviewWith>
 
   <Style Selector="controls|PopupMaster">
@@ -13,7 +13,7 @@
         <ItemsControl Items="{TemplateBinding Children}">
             <ItemsControl.Styles>
                 <Style Selector="controls|BasicPopup">
-                    <Setter Property="Height" Value="690"></Setter>
+                    <Setter Property="Height" Value="720"></Setter>
                     <Setter Property="Width" Value="1125"></Setter>
                 </Style>
             </ItemsControl.Styles>

--- a/Assist/Controls/TitleBars/TitleBar_Win.axaml
+++ b/Assist/Controls/TitleBars/TitleBar_Win.axaml
@@ -6,7 +6,7 @@
              d:DesignWidth="1000" 
              d:DesignHeight="30"
              x:Class="Assist.Controls.TitleBars.TitleBar_Win"
-             Background="{StaticResource AssistBlack}"
+             Background="Transparent"
              PointerPressed="InputElement_OnPointerPressed">
 
 	<UserControl.Styles>
@@ -31,8 +31,6 @@
 	</UserControl.Styles>
 
 	<Grid x:Name="titleGrid"
-          Background="{StaticResource AssistRed}"
-          
           PointerPressed="InputElement_OnPointerPressed">
 
         <Label Content="ASSIST BETA"

--- a/Assist/MainWindow.axaml
+++ b/Assist/MainWindow.axaml
@@ -20,23 +20,17 @@
         ExtendClientAreaChromeHints="NoChrome"
         ExtendClientAreaTitleBarHeightHint="30"
         Icon="/Resources/Assist_DevIcon.ico"
-        Opened="MainWindow_Initialized"
-        Background="{StaticResource AssistBlack}">
+        Opened="MainWindow_Initialized">
 
     <Design.DataContext>
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-	
+ 
 
 	<Grid RowDefinitions="30,*">
 
-		<!--Window Bar-->
-        <Grid Row="0" Background="{StaticResource AssistBlack}">
-            <winb:TitleBar_Win></winb:TitleBar_Win>
-        </Grid>
-
-		<LayoutTransformControl Grid.Row="1" x:Name="LayoutControl">
+		<LayoutTransformControl Grid.Row="0" Grid.RowSpan="2" x:Name="LayoutControl">
             <LayoutTransformControl.LayoutTransform>
                 <ScaleTransform ScaleY="{Binding ScaleRate}"
                                 ScaleX="{Binding ScaleRate}"></ScaleTransform>
@@ -45,9 +39,8 @@
 			<Grid>
                 <Grid x:Name="MainContentView"
                       Width="1125"
-                      Height="690"
-                      VerticalAlignment="Center"
-                      Background="{StaticResource AssistGray}">
+                      Height="720"
+                      VerticalAlignment="Center">
                     <TransitioningContentControl x:Name="ContentView" >
                         <TransitioningContentControl.PageTransition>
                             <CrossFade Duration="0:00:00.250"/>
@@ -57,9 +50,14 @@
 <StackPanel></StackPanel>
                 <popup:PopupMaster x:Name="PopupMaster" 
                                    Width="1125"
-                                   Height="690"/>
+                                   Height="720"/>
 			</Grid>
 		</LayoutTransformControl>
-        
+
+		<!--Window Bar-->
+        <Grid Row="0">
+            <winb:TitleBar_Win></winb:TitleBar_Win>
+        </Grid>
+
     </Grid>
 </Window>

--- a/Assist/Views/MainView.axaml
+++ b/Assist/Views/MainView.axaml
@@ -7,18 +7,24 @@
              xmlns:navigation="clr-namespace:Assist.Controls.Global.Navigation"
              mc:Ignorable="d" 
              d:DesignWidth="1125" 
-             d:DesignHeight="690"
+             d:DesignHeight="720"
              x:Class="Assist.Views.MainView"
-             Background="{StaticResource AssistBlack}"
-             Initialized="MainView_Initializaed">
+             Initialized="MainView_Initializaed"
+			 Padding="0,30,0,0">
+
+	<UserControl.Background>
+		<VisualBrush Stretch="UniformToFill">
+			<VisualBrush.Visual>
+				<Grid>
+					<Image Source="/Resources/background_dev.png" Stretch="UniformToFill"/>
+					<Rectangle Fill="black" Opacity=".8"></Rectangle>
+				</Grid>
+			</VisualBrush.Visual>
+		</VisualBrush>
+	</UserControl.Background>
 
     <Grid RowDefinitions="80, *">
-        
-        
-<Grid Grid.Row="0" Grid.RowSpan="2" x:Name="Background">
-	<Image Source="/Resources/background_dev.png" Stretch="UniformToFill"/>
-    <Rectangle Fill="black" Opacity=".8"></Rectangle>
-</Grid>
+
 	    <global:UserSelection Grid.RowSpan="2"  Width="240"
 	                          ZIndex="9999"
 	                          HorizontalAlignment="Right"


### PR DESCRIPTION
Currently, the title bar is the largest element in the interface that uses the primary, very bright color. The user should not notice the title bar because everyone instinctively knows where it is, but it is the first thing that catches the eye when the application is launched. Instead, the user should focus on other features of the application.

I changed the color of the title bar to transparent instead of solid gray because I think it makes the interface look more modern. Alternatively, I can change the background of the title bar to some color with partial transparency to make the title bar area visible, but I don't think it's necessary.