### PR TITLE
Riot games private model support

### DIFF
--- a/Assist/Objects/RiotClient/RiotGamesPrivateModel.cs
+++ b/Assist/Objects/RiotClient/RiotGamesPrivateModel.cs
@@ -10,6 +10,15 @@ namespace Assist.Objects.RiotClient
 
         [YamlMember(Alias = "rso-authenticator", ApplyNamingConventions = false)]
         public object? rsoAuth = null;
+
+        [YamlMember(Alias = "singular", ApplyNamingConventions = false)]
+        public object? HasCompletedFirstRun = null;
+    }
+
+    public class HasCompletedFirstRun
+    {
+        [YamlMember(Alias = "has_completed_first_run", ApplyNamingConventions = false)]
+        public string has_completed_first_run;
     }
 
     public class RiotLoginSection

--- a/Assist/Views/Authentication/Sections/ViewModels/RCAuthViewModel.cs
+++ b/Assist/Views/Authentication/Sections/ViewModels/RCAuthViewModel.cs
@@ -126,7 +126,9 @@ namespace Assist.Views.Authentication.Sections.ViewModels
                 var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
                     .WithNamingConvention(CamelCaseNamingConvention.Instance)
                     .Build();
-                settings = deserializer.Deserialize<RiotGamesPrivateModel>(File.ReadAllText(defaultConfigPath));
+
+                string rgpm = File.ReadAllText(defaultConfigPath);
+                settings = deserializer.Deserialize<RiotGamesPrivateModel>(rgpm);
             }
             catch (Exception e)
             {

--- a/Assist/Views/Authentication/Sections/ViewModels/RCAuthViewModel.cs
+++ b/Assist/Views/Authentication/Sections/ViewModels/RCAuthViewModel.cs
@@ -127,8 +127,7 @@ namespace Assist.Views.Authentication.Sections.ViewModels
                     .WithNamingConvention(CamelCaseNamingConvention.Instance)
                     .Build();
 
-                string rgpm = File.ReadAllText(defaultConfigPath);
-                settings = deserializer.Deserialize<RiotGamesPrivateModel>(rgpm);
+                settings = deserializer.Deserialize<RiotGamesPrivateModel>(File.ReadAllText(defaultConfigPath));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
RiotGamesPrivateModel.yaml config file CAN have a "singular" object with the sub-attribute "has_completed_first_run" which causes Assist to crash